### PR TITLE
[OV-8441] Add Dependabot PR auto-tagger reusable workflow

### DIFF
--- a/.github/workflows/dependabot_auto_tag.yml
+++ b/.github/workflows/dependabot_auto_tag.yml
@@ -1,0 +1,155 @@
+name: Dependabot Auto-Tagger
+
+on:
+  workflow_call:
+    secrets:
+      JIRA_API_TOKEN:
+        required: true
+      JIRA_USER_EMAIL:
+        required: true
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Check if PR already tagged
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const match = title.match(/^\[OV-(\d+)\]/);
+            if (match) {
+              core.setOutput('already_tagged', 'true');
+              console.log(`PR already tagged with [OV-${match[1]}], skipping.`);
+            } else {
+              core.setOutput('already_tagged', 'false');
+            }
+
+      - name: Create Jira Task
+        id: jira
+        if: steps.check.outputs.already_tagged == 'false'
+        shell: bash
+        env:
+          JIRA_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO_NAME: ${{ github.repository }}
+        run: |
+          REPO_SHORT="${REPO_NAME##*/}"
+          SUMMARY="[Dependabot] ${REPO_SHORT}: ${PR_TITLE}"
+          SUMMARY="${SUMMARY:0:255}"
+
+          PAYLOAD=$(jq -n \
+            --arg summary "$SUMMARY" \
+            --arg pr_url "$PR_URL" \
+            --arg pr_title "$PR_TITLE" \
+            --arg repo "$REPO_NAME" \
+            '{
+              fields: {
+                project: { key: "OV" },
+                issuetype: { id: "10002" },
+                summary: $summary,
+                labels: ["dependabot", "dependencies"],
+                description: {
+                  version: 1,
+                  type: "doc",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        { type: "text", text: "Auto-created from Dependabot PR: " },
+                        { type: "text", text: $pr_title, marks: [{ type: "strong" }] }
+                      ]
+                    },
+                    {
+                      type: "paragraph",
+                      content: [
+                        { type: "text", text: "Repository: " },
+                        { type: "text", text: $repo }
+                      ]
+                    },
+                    {
+                      type: "paragraph",
+                      content: [
+                        { type: "text", text: "PR: " },
+                        {
+                          type: "text",
+                          text: $pr_url,
+                          marks: [{ type: "link", attrs: { href: $pr_url } }]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }')
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST \
+            -H "Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_TOKEN}" | base64)" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "https://ovalix.atlassian.net/rest/api/3/issue")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" -ne 201 ]; then
+            echo "::error::Jira API returned HTTP $HTTP_CODE: $BODY"
+            exit 1
+          fi
+
+          TICKET_KEY=$(echo "$BODY" | jq -r '.key')
+          echo "ticket_key=$TICKET_KEY" >> "$GITHUB_OUTPUT"
+          echo "Created Jira ticket: $TICKET_KEY"
+
+      - name: Update PR title, body, and labels
+        if: steps.check.outputs.already_tagged == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ticketKey = '${{ steps.jira.outputs.ticket_key }}';
+            const originalTitle = context.payload.pull_request.title;
+            const prNumber = context.payload.pull_request.number;
+            const jiraUrl = `https://ovalix.atlassian.net/browse/${ticketKey}`;
+
+            const newTitle = `[${ticketKey}] ${originalTitle}`;
+
+            const newBody = [
+              '<!--- TRIVIAL PR -->',
+              '',
+              '## Tickets',
+              '',
+              `- [${ticketKey}](${jiraUrl})`,
+              '',
+              '## Trivial PR',
+              '',
+              `Dependabot dependency update: ${originalTitle}`,
+              '',
+              '## PR Checklist',
+              '',
+              '- [ ] **Trivial PR.** Reviewer agrees this PR is trivial.',
+            ].join('\n');
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              title: newTitle,
+              body: newBody,
+            });
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['dependencies'],
+            });
+
+            console.log(`Updated PR #${prNumber}: title="${newTitle}"`);


### PR DESCRIPTION
Reusable GitHub Action that automatically creates a Jira ticket and reformats Dependabot PRs to match the org PR conventions.

<!--- TRIVIAL PR -->

## Tickets

- OV-8441

## Trivial PR

<!--- This PR is for a trivial change that is extremely small, and either does not affect behavior or is self-evidently correct. 
Provide detail here as necessary.-->

## PR Checklist 

- [ ] **Trivial PR.** Reviewer agrees this PR is trivial.